### PR TITLE
update readme.md to reflect supported py version

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ termgraph --calendar --start-dt 2017-07-01 data/cal.dat
 
 ### Install
 
-Requires Python 3.5+, install from [PyPI project](https://pypi.org/project/termgraph/)
+Requires Python 3.6+, install from [PyPI project](https://pypi.org/project/termgraph/)
 
 ```
 python -m pip install termgraph


### PR DESCRIPTION
Termgraph uses f-strings in `termgraph/termgraph.py", line 327` and this means py3.5 is not supported. F-strings were introduced in 3.6 